### PR TITLE
feat: adapted colors for dark mode

### DIFF
--- a/composed-variables/composed-variables.css
+++ b/composed-variables/composed-variables.css
@@ -7,6 +7,22 @@
    * Due to technical limitations these variables are only provided as CSS variables.
    */
 
+  /* Colors */
+  --sbb-color-sky: light-dark(var(--sbb-color-sky-light), var(--sbb-color-sky-dark));
+  --sbb-color-night: light-dark(var(--sbb-color-night-light), var(--sbb-color-night-dark));
+  --sbb-color-violet: light-dark(var(--sbb-color-violet-light), var(--sbb-color-violet-dark));
+  --sbb-color-pink: light-dark(var(--sbb-color-pink-light), var(--sbb-color-pink-dark));
+  --sbb-color-autumn: light-dark(var(--sbb-color-autumn-light), var(--sbb-color-autumn-dark));
+  --sbb-color-orange: light-dark(var(--sbb-color-orange-light), var(--sbb-color-orange-dark));
+  --sbb-color-peach: light-dark(var(--sbb-color-peach-light), var(--sbb-color-peach-dark));
+  --sbb-color-lemon: light-dark(var(--sbb-color-lemon-light), var(--sbb-color-lemon-dark));
+  --sbb-color-brown: light-dark(var(--sbb-color-brown-light), var(--sbb-color-brown-dark));
+  --sbb-color-green: light-dark(var(--sbb-color-green-light), var(--sbb-color-green-dark));
+  --sbb-color-turquoise: light-dark(
+    var(--sbb-color-turquoise-light),
+    var(--sbb-color-turquoise-dark)
+  );
+
   /* Font Color */
   --sbb-font-default-color: var(--sbb-color-charcoal);
 

--- a/designTokens/color.ts
+++ b/designTokens/color.ts
@@ -143,7 +143,7 @@ export const color: DesignTokens = {
   },
   redMode: {
     dark: {
-      value: 'rgb(255,56,56,1)',
+      value: 'rgba(255,56,56,1)',
     },
   },
   red125: {
@@ -198,37 +198,70 @@ export const color: DesignTokens = {
       value: 'rgba(255,255,255,.8)',
     },
   },
-  sky: {
+  skyLight: {
     value: 'rgba(0,116,191,1)',
   },
-  night: {
+  skyDark: {
+    value: 'rgba(18,142,222,1)',
+  },
+  nightLight: {
     value: 'rgba(20,58,133,1)',
   },
-  violet: {
+  nightDark: {
+    value: 'rgba(101,135,202,1)',
+  },
+  violetLight: {
     value: 'rgba(111,34,130,1)',
   },
-  pink: {
+  violetDark: {
+    value: 'rgba(179,108,197,1)',
+  },
+  pinkLight: {
     value: 'rgba(199,56,122,1)',
   },
-  autumn: {
+  pinkDark: {
+    value: 'rgba(228,82,149,1)',
+  },
+  autumnLight: {
     value: 'rgba(207,59,0,1)',
   },
-  orange: {
+  autumnDark: {
+    value: 'rgba(240,83,19,1)',
+  },
+  orangeLight: {
     value: 'rgba(242,126,0,1)',
   },
-  peach: {
+  orangeDark: {
+    value: 'rgba(251,142,25,1)',
+  },
+  peachLight: {
     value: 'rgba(252,187,0,1)',
   },
-  lemon: {
+  peachDark: {
+    value: 'rgba(255,199,39,1)',
+  },
+  lemonLight: {
     value: 'rgba(255,222,21,1)',
   },
-  brown: {
+  lemonDark: {
+    value: 'rgba(255,229,71,1)',
+  },
+  brownLight: {
     value: 'rgba(160,84,0,1)',
   },
-  green: {
+  brownDark: {
+    value: 'rgba(207,111,4)',
+  },
+  greenLight: {
     value: 'rgba(0,130,51,1)',
   },
-  turquoise: {
+  greenDark: {
+    value: 'rgba(16,157,71,1)',
+  },
+  turquoiseLight: {
     value: 'rgba(0,126,132,1)',
+  },
+  turquoiseDark: {
+    value: 'rgba(0,165,155,1)',
   },
 };


### PR DESCRIPTION
BREAKING CHANGE: The additional colors needed to be adapted for the dark mode. Therefore, every additional color now has a light and a dark variant.
CSS variables are consumable like before, but colors are automatically adapted depending on active color-scheme.